### PR TITLE
feat: legal-wayfinder — decision-map protocol for legal matters (v4.10.0)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,7 +8,7 @@
     {
       "name": "bettercallclaude",
       "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
-      "version": "4.9.6",
+      "version": "4.10.0",
       "source": "./bettercallclaude",
       "author": {
         "name": "Federico Cesconi"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to BetterCallClaude will be documented in this file.
 
 ---
 
+## [4.10.0] - 2026-08-19
+
+### Added
+- **Wayfinder decision maps for big legal matters** — new `/legal-chart` and `/legal-way` commands plus the `legal-wayfinder` skill: chart a matter too big or too foggy for one session as a file-based map (destination, decisions so far, fog, out-of-scope) with decision tickets under `bcc-output/<matter>/wayfinder/`, work one ticket per invocation, hand off to `/legal-5step` or the orchestrator when the route is clear. Privacy follows the existing routing matrix including a no-ollama degradation path (fail-closed). `/briefing` now offers charting for foggy high-complexity matters.
+
 ## [4.9.6] - 2026-08-04
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Version](https://img.shields.io/badge/version-4.9.6-blue)](https://github.com/fedec65/bettercallclaude/releases)
+[![Version](https://img.shields.io/badge/version-4.10.0-blue)](https://github.com/fedec65/bettercallclaude/releases)
 [![License: AGPL-3.0](https://img.shields.io/badge/license-AGPL--3.0-green)](LICENSE)
 [![Platform](https://img.shields.io/badge/platform-Cowork%20Desktop-orange)](https://claude.ai)
 [![Website](https://img.shields.io/badge/web-bettercallclaude.ch-brightgreen)](https://bettercallclaude.ch)
@@ -25,13 +25,11 @@ BetterCallClaude provides a structured methodology for handling legal work with 
 
 ---
 
-## What's New in v4.9.6
+## What's New in v4.10.0
 
-**v4.9.6 — Critical privacy fix: the Anwaltsgeheimnis hook now works on every installation path.** We found and fixed a silent failure: if your plugin path contains spaces (e.g. a user name with a space), the PreToolUse privacy scan did not run at all — with no error shown. The hook command now quotes the plugin root correctly. If you handle privileged client content, update now.
+**v4.10.0 — Legal wayfinder: decision maps for matters too big or too foggy for one plan.** `/legal-chart` decomposes a matter into a decision map — destination, decisions so far, fog, out-of-scope — with one ticket per open decision. `/legal-way` then works the map ticket by ticket (research, grilling, prototype, task) until the route to the deliverable is clear and hands off to execution. A fog check in `/briefing` routes oversized matters to the chart instead of forcing a static execution plan.
 
-- **What happened** — `hooks/hooks.json` invoked the privacy scanner without quoting `${CLAUDE_PLUGIN_ROOT}`. On spaced paths the shell split the command, the hook failed to load, and privilege detection was silently off.
-- **What else was fixed** — the same quoting bug in the v4.9.5 `/legal-timeline` render commands; regression guards added (standalone tests + a CI check that fails the build on any unquoted occurrence).
-- **Thanks** — the same bug was first spotted and fixed in the Italian plugin (v1.2.6); their report brought it to our attention here.
+**Also in recent releases — v4.9.6 privacy fix**: the Anwaltsgeheimnis PreToolUse hook silently failed on plugin paths containing spaces (e.g. a user name with a space) — privilege detection was off with no error shown. The hook command now quotes the plugin root correctly, with regression guards (standalone tests + a CI check). If you handle privileged client content, update.
 
 **Also in recent releases — v4.9.5 `/legal-timeline`**: build a sourced case chronology from your case documents: every event carries its document and locus, contested facts and date conflicts are made visible (never silently resolved), evidentiary gaps of 30+ days are flagged, and procedural deadlines are computed via MCP with cantonal holiday calendars. Three outputs (Markdown table, interactive HTML, Word export) under `bcc-output/timeline/`.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 <p align="center"><strong>Swiss Legal Intelligence Plugin for Cowork Desktop</strong></p>
 
-BetterCallClaude transforms legal research, case strategy, and document drafting for Swiss lawyers. It provides deep integration with Swiss legal databases, multi-lingual analysis (DE/FR/IT/EN), and built-in Anwaltsgeheimnis (attorney-client privilege) protection -- 21 agents, 27 commands, 16 skills, and 9 MCP servers covering BGE/ATF/DTF precedent research, litigation strategy, adversarial analysis, legal drafting, citation verification, document intelligence, and CAS/TAS sports arbitration across all 26 Swiss cantons.
+BetterCallClaude transforms legal research, case strategy, and document drafting for Swiss lawyers. It provides deep integration with Swiss legal databases, multi-lingual analysis (DE/FR/IT/EN), and built-in Anwaltsgeheimnis (attorney-client privilege) protection -- 21 agents, 29 commands, 17 skills, and 9 MCP servers covering BGE/ATF/DTF precedent research, litigation strategy, adversarial analysis, legal drafting, citation verification, document intelligence, and CAS/TAS sports arbitration across all 26 Swiss cantons.
 
 > **Claude Code CLI users**: this repository is Cowork Desktop only. The CLI version is at [fedec65/bettercallclaude-cli](https://github.com/fedec65/bettercallclaude-cli).
 
@@ -35,7 +35,7 @@ BetterCallClaude provides a structured methodology for handling legal work with 
 
 **Also in recent releases — v4.9.5 `/legal-timeline`**: build a sourced case chronology from your case documents: every event carries its document and locus, contested facts and date conflicts are made visible (never silently resolved), evidentiary gaps of 30+ days are flagged, and procedural deadlines are computed via MCP with cantonal holiday calendars. Three outputs (Markdown table, interactive HTML, Word export) under `bcc-output/timeline/`.
 
-**Content counts**: 21 agents, 27 commands, 16 skills, 9 MCP servers in `.mcp.json` (7 remote HTTP on `mcp.bettercallclaude.ch` + `swiss-caselaw` SSE on `mcp.opencaselaw.ch` + `ollama` local STDIO).
+**Content counts**: 21 agents, 29 commands, 17 skills, 9 MCP servers in `.mcp.json` (7 remote HTTP on `mcp.bettercallclaude.ch` + `swiss-caselaw` SSE on `mcp.opencaselaw.ch` + `ollama` local STDIO).
 
 [Full changelog →](CHANGELOG.md)
 

--- a/bettercallclaude/.claude-plugin/plugin.json
+++ b/bettercallclaude/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.9.6",
+  "version": "4.10.0",
   "description": "Swiss Legal Intelligence -- BGE/ATF/DTF precedent research, case strategy, legal drafting, and citation verification across all 26 Swiss cantons with Anwaltsgeheimnis privacy protection.",
   "author": { "name": "Federico Cesconi" },
   "userConfig": {

--- a/bettercallclaude/README.md
+++ b/bettercallclaude/README.md
@@ -6,7 +6,7 @@ BetterCallClaude is a plugin for legal professionals working in Cowork or Claude
 
 The plugin covers the full spectrum of Swiss legal work: BGE/ATF/DTF precedent research, case strategy development with risk assessment, adversarial legal analysis, compliance and data protection advisory, fiscal and corporate law expertise, real estate law, legal drafting with jurisdiction-aware templates, legal translation, and citation verification across all 26 Swiss cantons. Privacy compliance with Anwaltsgeheimnis (Art. 321 StGB) is enforced automatically through a pre-tool-use hook that detects privileged content before it leaves the local environment.
 
-**Version**: 4.9.6 -- 21 agents, 27 commands, 16 skills, 9 MCP servers.
+**Version**: 4.10.0 -- 21 agents, 29 commands, 17 skills, 9 MCP servers.
 
 > Love BetterCallClaude? Support the project — [**Buy me a coffee**](https://buymeacoffee.com/federicocesconi) ☕
 
@@ -18,7 +18,7 @@ BetterCallClaude can be installed through several channels.
 
 ### Claude Cowork (Recommended)
 
-Visit the installation page at **[bettercallclaude.ai/desktop](https://bettercallclaude.ai/desktop)** for guided setup instructions. The page walks you through installing the plugin directly in Claude Cowork with a few clicks.
+Follow the **[BetterCallClaude Tutorial](https://github.com/fedec65/bettercallclaude_tutorial)** for guided setup instructions with screenshots. The tutorial walks you through installing the plugin directly in Claude Cowork with a few clicks.
 
 ### From GitHub (Claude Code CLI)
 

--- a/bettercallclaude/README.md
+++ b/bettercallclaude/README.md
@@ -92,6 +92,8 @@ claude --plugin-dir bettercallclaude/
 | `/bettercallclaude:cantonal` | Analyze a legal question under cantonal law for a specific canton. |
 | `/bettercallclaude:adversarial` | Run three-agent adversarial analysis -- advocate builds the case, adversary challenges it, judicial analyst synthesizes. |
 | `/bettercallclaude:briefing` | Structured pre-execution briefing session -- assembles a specialist panel, collects case context, and builds an execution plan before agents start working. Supports resume and depth control. |
+| `/bettercallclaude:legal-chart` | Chart a big or foggy matter as a wayfinder decision map -- destination, decisions so far, fog, out-of-scope -- with one ticket per open decision. Planning only; charting resolves no decisions itself. |
+| `/bettercallclaude:legal-way` | Work one decision ticket from a wayfinder map (research, grilling, prototype, task); emits the handoff pack to execution when every decision is made. Supports `--list` and `--gate`. |
 | `/bettercallclaude:workflow` | Define and execute multi-agent legal workflows (due diligence, litigation prep, contract lifecycle, real estate closing). |
 | `/bettercallclaude:translate` | Translate Swiss legal documents between DE, FR, IT, and EN while preserving legal terminology precision. |
 | `/bettercallclaude:doc-analyze` | Analyze Swiss legal documents -- identify legal issues, extract key clauses, verify citations, assess compliance. |
@@ -148,6 +150,7 @@ Skills are activated automatically when Claude detects relevant legal context in
 | `compliance-frameworks` | FINMA supervision, GwG/AMLA anti-money laundering, FIDLEG/FINIG financial institution licensing, banking secrecy, and cross-border compliance. |
 | `data-protection-law` | nDSG/FADP framework, GDPR adequacy, cantonal data protection laws (IDG/KDSG/LIPAD), DPIA methodology, and cross-border data transfers. |
 | `legal-briefing` | Auto-detects complex queries that benefit from structured intake before agent execution. Suggests briefing sessions when complexity, ambiguity, or pipeline coordination is detected. |
+| `legal-wayfinder` | Decision-map decomposition for matters too big or foggy for one execution plan -- ticket protocol, frontier computation, fog checks, honest termination, and the handoff pack to execution. |
 
 ---
 
@@ -280,6 +283,40 @@ The **briefing session** adds a collaborative intake phase between your query an
 
 # Force briefing on a query that would normally route directly
 /bettercallclaude:legal --briefing Find BGE on Art. 97 OR foreseeability
+```
+
+---
+
+### Wayfinder Decision Maps (New in v4.10.0)
+
+The briefing session assumes the route to your deliverable can be planned now: it collects context and builds an execution plan. Some matters break that assumption. When the case is too big or too **foggy** -- limitation period unclear, forum contested, key evidence not yet obtainable, client's risk appetite unknown -- open decisions must be *made* before any execution plan can be trusted. A plan built over fog just guesses earlier.
+
+**Briefing vs. wayfinder in one line**: `/briefing` plans the *work* when the decisions are clear; `/legal-chart` maps the *decisions* when they are not. They feed each other: a fog check in the briefing routes oversized matters to the chart, and the chart's early exit (matter is actually clear) sends you back to briefing or `/legal-5step`.
+
+**How it works**:
+
+1. **Chart** (`/legal-chart`) -- grill the attorney breadth-first to pin the deliverable ("file-ready Klageschrift", "DD report for the SPA"), then write a file-based map under `bcc-output/YYYY-MM-DD-<slug>/wayfinder/`: destination, decisions so far, fog (not yet specified), out-of-scope. Every open decision becomes a ticket (`research`, `grilling`, `prototype`, or `task` type) with explicit `blocked-by` dependencies. Research tickets are fired as parallel subagents during charting; nothing else is resolved.
+
+2. **Work** (`/legal-way`) -- one ticket per invocation. The command claims the lowest-numbered **frontier** ticket (open, unclaimed, all blockers resolved or ruled out) and resolves it by type: AFK research via MCP servers, or human-in-the-loop grilling/prototype for facts only you or the client can supply. Each resolution is recorded on the ticket and as a one-line decision on the map; newly sharp fog graduates into new tickets.
+
+3. **Hand off** -- only when *every* ticket is resolved or ruled out and no fog remains, `/legal-way` emits a **handoff pack** (destination + decisions + linked assets) and routes to `/legal-5step` or the orchestrator. The map never hands off over an unresolved decision -- that is the feature's core guarantee. With `--gate`, a `/legal-goal` record is pre-built so execution runs under the worker-evaluator loop.
+
+**Usage examples**:
+
+```
+# Chart a foggy matter into a decision map
+/bettercallclaude:legal-chart Enforcement of a CHF 2M guarantee against two
+  co-debtors, one possibly insolvent, forum dispute ZH vs. seat of company
+
+# Work the next open decision (or a named one)
+/bettercallclaude:legal-way
+/bettercallclaude:legal-way t03 --privacy=strict
+
+# List existing maps with frontier counts
+/bettercallclaude:legal-way --list
+
+# Hand off under the worker-evaluator loop when the map is clear
+/bettercallclaude:legal-way --gate
 ```
 
 ---

--- a/bettercallclaude/agents/briefing.md
+++ b/bettercallclaude/agents/briefing.md
@@ -164,6 +164,12 @@ Persist state after each round.
 
 ### Step 6: BUILD EXECUTION PLAN
 
+**Fog check first.** If the matter is too foggy for a static plan — complexity 8+, or
+open decisions that depend on other open decisions — stop plan-building and offer the
+attorney: *"This matter is too foggy for a static plan — chart it instead?"* →
+`/bettercallclaude:legal-chart`. Only construct the execution plan when the way is
+clear or the attorney declines charting.
+
 Using the classification and all collected answers, construct the execution plan.
 
 **User-facing table** (always present this):

--- a/bettercallclaude/commands/briefing.md
+++ b/bettercallclaude/commands/briefing.md
@@ -37,6 +37,7 @@ Parse flags from the user's input to determine the mode:
 | `--medium` | Set execution plan output length to medium (default, 3–5 pages) |
 | `--long` | Set execution plan output length to long (full detail) |
 | `--skip-briefing` | Bypass briefing and route directly (pass through to `/legal`) |
+| `--chart` | Route to `/bettercallclaude:legal-chart` (wayfinder decision map) instead of a static execution plan — for matters too big or too foggy for one plan |
 
 **Natural language equivalents**: You can also say:
 - "riprendi il briefing precedente" or "resume the last briefing" → `--resume`
@@ -109,6 +110,7 @@ If the user skips, proceed with the original query and flag the gaps in the exec
    - Select and consult a specialist panel (skipped if `--depth quick`)
    - Compile and ask clarifying questions in adaptive rounds
    - Build a structured execution plan
+   - **Fog check**: if the matter is too foggy for a static plan (complexity 8+, or open decisions that depend on other open decisions), stop plan-building and offer: *"This matter is too foggy for a static plan — chart it instead?"* → `/bettercallclaude:legal-chart`
    - Present the plan for user review and refinement
 4. On plan approval:
    - **Execute immediately**: Hand off to orchestrator with checkpoints

--- a/bettercallclaude/commands/briefing.md
+++ b/bettercallclaude/commands/briefing.md
@@ -22,6 +22,7 @@ Parse flags from the user's input to determine the mode:
 2. **Resume** (`--resume [id]`): Resume a previously saved or paused briefing. If no ID provided, load `briefing_latest`.
 3. **List** (`--list`): Display all saved briefings from `briefing_index`.
 4. **Skip** (`--skip-briefing`): Bypass the briefing flow entirely and route the query straight to `/bettercallclaude:legal --skip-briefing`. The briefing coordinator is **not** invoked. Used by the `legal-intake` skill on the user's "Skip briefing" choice and by users who explicitly want to bypass intake on a `/briefing` invocation.
+5. **Chart** (`--chart`): Bypass the briefing flow entirely and route the query straight to `/bettercallclaude:legal-chart`. The briefing coordinator is **not** invoked. Used for matters too big or too foggy for one static execution plan.
 
 ## Flags
 
@@ -45,6 +46,7 @@ Parse flags from the user's input to determine the mode:
 - "briefing veloce" or "quick briefing" → `--depth quick`
 - "briefing approfondito" or "deep briefing" → `--depth deep`
 - "salta il briefing" or "skip the briefing" → `--skip-briefing`
+- "traccia la mappa" or "chart it" → `--chart`
 - "output breve / medio / dettagliato" → `--short` / `--medium` / `--long`
 
 **Flag parsing tip**: Flags appear anywhere in the input. Extract them before passing the query text to the briefing coordinator. Example: `"Advise on termination --depth quick"` → flag: `--depth quick`, query: `"Advise on termination"`.
@@ -98,6 +100,15 @@ If the user skips, proceed with the original query and flag the gaps in the exec
 3. Route the original query directly to `/bettercallclaude:legal --skip-briefing [remaining flags] [query]`. The downstream `/legal` command will see the flag and will not re-activate the `legal-intake` skill on the same query.
 4. Stop. Do not continue into the New / Resume / List branches below.
 
+### Pre-flight: Chart
+
+**Before any other branch except Pre-flight: Skip**, check for `--chart` in the parsed flags. If present:
+
+1. Do **not** invoke the briefing coordinator, the vagueness check, or the specialist panel.
+2. Strip the `--chart` flag from the parsed flag list (it has been consumed here).
+3. Route the original query directly to `/bettercallclaude:legal-chart [remaining flags] [query]`.
+4. Stop. Do not continue into the New / Resume / List branches below.
+
 ### New Briefing
 
 1. Run the pre-flight vagueness check (if applicable — see above).
@@ -109,8 +120,8 @@ If the user skips, proceed with the original query and flag the gaps in the exec
    - Classify the query (domain, jurisdiction, complexity, language)
    - Select and consult a specialist panel (skipped if `--depth quick`)
    - Compile and ask clarifying questions in adaptive rounds
-   - Build a structured execution plan
    - **Fog check**: if the matter is too foggy for a static plan (complexity 8+, or open decisions that depend on other open decisions), stop plan-building and offer: *"This matter is too foggy for a static plan — chart it instead?"* → `/bettercallclaude:legal-chart`
+   - Build a structured execution plan
    - Present the plan for user review and refinement
 4. On plan approval:
    - **Execute immediately**: Hand off to orchestrator with checkpoints

--- a/bettercallclaude/commands/help.md
+++ b/bettercallclaude/commands/help.md
@@ -215,7 +215,7 @@ Skills activate automatically when Claude detects relevant context.
 
 ---
 
-**BetterCallClaude v4.9.6 -- Swiss Legal Intelligence for Cowork Desktop**
+**BetterCallClaude v4.10.0 -- Swiss Legal Intelligence for Cowork Desktop**
 
 If the user provided additional input, respond to it in the context of this help reference.
 

--- a/bettercallclaude/commands/help.md
+++ b/bettercallclaude/commands/help.md
@@ -26,7 +26,7 @@ BetterCallClaude provides Swiss legal intelligence through three interfaces:
 
 ---
 
-## Commands (27)
+## Commands (29)
 
 ### Core Commands
 
@@ -113,7 +113,7 @@ BetterCallClaude provides Swiss legal intelligence through three interfaces:
 
 ---
 
-## Skills (16)
+## Skills (17)
 
 Skills activate automatically when Claude detects relevant context.
 

--- a/bettercallclaude/commands/help.md
+++ b/bettercallclaude/commands/help.md
@@ -61,6 +61,8 @@ BetterCallClaude provides Swiss legal intelligence through three interfaces:
 |---------|-------------|
 | `/bettercallclaude:workflow` | Define and execute multi-agent pipelines |
 | `/bettercallclaude:briefing` | Structured pre-execution briefing with specialist panel and plan building |
+| `/bettercallclaude:legal-chart` | Chart a big/foggy matter as a wayfinder decision map |
+| `/bettercallclaude:legal-way` | Work one decision ticket from a wayfinder map |
 | `/bettercallclaude:translate` | Translate legal documents between DE, FR, IT, EN |
 
 ### Reference Commands
@@ -132,6 +134,7 @@ Skills activate automatically when Claude detects relevant context.
 | legal-intake | Complex queries needing structured intake or refinement before execution |
 | legal-5step-framework | End-to-end 5-step legal analysis pipeline |
 | legal-evaluator | Verdict engine for /legal-loop worker-evaluator cycles |
+| legal-wayfinder | Decision-map decomposition for matters too big or foggy for one session |
 | shared (output-conventions) | Deliverable-as-file output conventions for all commands |
 
 ---

--- a/bettercallclaude/commands/legal-chart.md
+++ b/bettercallclaude/commands/legal-chart.md
@@ -1,0 +1,94 @@
+---
+description: "Chart a big legal matter as a wayfinder decision map — grill the attorney breadth-first, create the map and decision tickets, fire research tickets in parallel. Planning only: charting resolves no decisions itself."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_bettercallclaude_bge-search__search_bge
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_canton
+  - mcp__plugin_bettercallclaude_fedlex-sparql__search_legislation
+  - mcp__plugin_bettercallclaude_fedlex-sparql__get_article
+  - mcp__plugin_bettercallclaude_swiss-caselaw__search_decisions
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_leading_cases
+  - mcp__plugin_bettercallclaude_swiss-caselaw__get_case_brief
+  - mcp__plugin_bettercallclaude_swiss-caselaw__cite
+  - mcp__plugin_bettercallclaude_onlinekommentar__search_commentaries
+  - mcp__plugin_bettercallclaude_ollama__ollama_check_status
+---
+
+# /legal-chart — Chart a Legal Decision Map
+
+You are invoked via `/bettercallclaude:legal-chart`. You apply the `legal-wayfinder`
+skill in full. Your sole purpose is to **chart** a big or foggy legal matter as a
+decision map: map file plus decision tickets. You resolve nothing yourself — that is
+`/legal-way`'s job.
+
+## Parameters
+
+- Query text: the matter description (free text).
+- `--privacy=<mode>`: privacy mode for the map (`strict`, `balanced`, `cloud`). Defaults to the configured mode.
+- `--lang=DE|FR|IT|EN`: map language. Defaults to auto-detect from input.
+- `--canton=XX`: cantonal jurisdiction (e.g. `--canton=ZH`). Defaults to federal.
+
+**Natural language equivalents**:
+- "traccia la mappa" or "chart the matter" → start charting
+- "matter privato" / "privacy strict" → `--privacy=strict`
+- "in tedesco" / "auf Deutsch" → `--lang=DE`
+- "giurisdizione Zurigo" / "Zurich jurisdiction" → `--canton=ZH`
+
+**Output convention**: write the map to `bcc-output/YYYY-MM-DD-<slug>/wayfinder/map.md`
+and tickets to `.../wayfinder/tickets/`. Give in chat only the map summary (destination,
+ticket list by name with types, fog count). See `skills/shared/SKILL.md`.
+
+## Charting Flow
+
+1. **Name the destination.** Grill the attorney (one question at a time) to pin the
+   deliverable — "file-ready Klageschrift", "DD report for the SPA". The destination
+   fixes scope, so it is settled first.
+2. **Breadth-first grill.** Fan out across the whole matter — jurisdiction, parties'
+   positions, limitation, forum, evidence availability, client risk appetite — never
+   deep on any one thread. Surface every open decision you can sense.
+
+   **Early exit — no fog:** if this surfaces no open decisions (the way to the
+   destination is already clear, the matter fits one execution plan), do NOT create a
+   map. Stop and tell the attorney:
+   ```
+   This matter is clear enough for direct execution — no map needed.
+   Options: /bettercallclaude:briefing (structured plan) or
+   /bettercallclaude:legal-5step (end-to-end pipeline).
+   ```
+
+3. **Probe the classifier** with `ollama_check_status` and record the result.
+4. **Create the map** (`status: charting`) with the fog sketched into *Not yet
+   specified*.
+5. **Create the tickets that are sharp now** as ticket files — then wire `blocked-by`
+   edges in a **second pass** (files need ids before they can reference each other).
+   Everything not yet phrasable stays in the fog.
+6. **Fire research tickets in parallel**: dispatch the researcher agent as subagents,
+   MCP servers in the standard priority order, R1/R2 enforced, privacy pre-check per
+   the map's privacy mode. Memos land in `assets/`. Research resolutions are recorded
+   on the tickets by those subagents.
+7. **Stop.** Report the charted map and end the session. Charting hand-resolves nothing.
+
+## Charting Rules
+
+- One session of work; never resolve a non-research ticket while charting.
+- Refer to tickets by name in everything the attorney reads.
+- Refer the attorney to `/bettercallclaude:legal-way` to work the map: *"Map charted.
+  Run `/bettercallclaude:legal-way` (or 'next ticket') to work the first ticket."*
+- If multiple maps already exist in the working folder, chart into a new dated folder —
+  never merge maps.
+
+## Plugin Scope Constraint
+
+For all charting tasks, use **exclusively** BetterCallClaude agents, skills, and MCP
+servers. Do not delegate legal work to generic or external skills, agents, or tools
+outside this plugin.
+
+## User Query
+
+$ARGUMENTS

--- a/bettercallclaude/commands/legal-chart.md
+++ b/bettercallclaude/commands/legal-chart.md
@@ -5,6 +5,7 @@ tools:
   - Grep
   - Glob
   - Bash
+  - Task
   - WebSearch
   - WebFetch
   - mcp__plugin_bettercallclaude_bge-search__search_bge

--- a/bettercallclaude/commands/legal-chart.md
+++ b/bettercallclaude/commands/legal-chart.md
@@ -72,7 +72,8 @@ ticket list by name with types, fog count). See `skills/shared/SKILL.md`.
    MCP servers in the standard priority order, R1/R2 enforced, privacy pre-check per
    the map's privacy mode. Memos land in `assets/`. Research resolutions are recorded
    on the tickets by those subagents.
-7. **Stop.** Report the charted map and end the session. Charting hand-resolves nothing.
+7. **Stop.** Report the charted map and end the session. The charting session itself
+   resolves no decisions — only the fired research tickets record resolutions.
 
 ## Charting Rules
 

--- a/bettercallclaude/commands/legal-way.md
+++ b/bettercallclaude/commands/legal-way.md
@@ -1,0 +1,114 @@
+---
+description: "Work one ticket from a legal-wayfinder decision map — claim a frontier ticket, resolve it by type (research / grilling / prototype / task), record the decision, graduate newly-sharp fog, and emit the handoff pack when the map is clear."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_bettercallclaude_bge-search__search_bge
+  - mcp__plugin_bettercallclaude_bge-search__get_bge_decision
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
+  - mcp__plugin_bettercallclaude_fedlex-sparql__search_legislation
+  - mcp__plugin_bettercallclaude_fedlex-sparql__get_article
+  - mcp__plugin_bettercallclaude_fedlex-sparql__lookup_statute
+  - mcp__plugin_bettercallclaude_legal-citations__validate_citation
+  - mcp__plugin_bettercallclaude_legal-citations__extract_citations
+  - mcp__plugin_bettercallclaude_legal-citations__review_citations
+  - mcp__plugin_bettercallclaude_onlinekommentar__search_commentaries
+  - mcp__plugin_bettercallclaude_swiss-caselaw__search_decisions
+  - mcp__plugin_bettercallclaude_swiss-caselaw__get_decision
+  - mcp__plugin_bettercallclaude_swiss-caselaw__get_case_brief
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_leading_cases
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_relevant_erwaegung
+  - mcp__plugin_bettercallclaude_swiss-caselaw__check_claim_support
+  - mcp__plugin_bettercallclaude_swiss-caselaw__cite
+  - mcp__plugin_bettercallclaude_ollama__ollama_check_status
+  - mcp__plugin_bettercallclaude_ollama__ollama_classify_privacy
+---
+
+# /legal-way — Work One Decision Ticket
+
+You are invoked via `/bettercallclaude:legal-way`. You apply the `legal-wayfinder`
+skill in full. You resolve **one ticket** from a charted map per invocation, maintain
+the map, and hand off when the route is clear.
+
+## Parameters
+
+- First positional argument (optional): a ticket id or title. Without one, pick the lowest-numbered frontier ticket.
+- `--map=<slug-or-path>`: which map to work. Default: if exactly one map exists under `bcc-output/*/wayfinder/`, use it; if several, list and ask.
+- `--gate`: on handoff, pre-build a `/legal-goal` Goal Record so execution runs under the worker–evaluator loop.
+- `--list`: show every map in the working folder with frontier count, and stop.
+
+**Natural language equivalents**:
+- "prossima tessera" or "next ticket" → work the lowest-numbered frontier ticket
+- "elenco mappe" or "list maps" → `--list`
+- "con gate" or "with gate" → `--gate`
+
+**Output convention**: update the ticket file and `map.md` in place under
+`bcc-output/<matter>/wayfinder/`; write research memos and prototypes to `assets/`. Give
+in chat the resolution summary and the updated frontier. See `skills/shared/SKILL.md`.
+
+## Pre-Flight Checks
+
+1. **Map exists.** If none found: `ERROR: No wayfinder map found. Run /bettercallclaude:legal-chart first.`
+2. **Map not handed off.** If `status: handed-off`, show the map summary and stop — the matter is in execution.
+3. **Privacy mode loaded** from map frontmatter; `classifier` respected without re-probing.
+
+## Working Flow
+
+1. **Load the map** — the low-res view: Destination, Notes, Decisions so far, fog,
+   Out of scope. Do not open every ticket body; zoom into related tickets on demand.
+2. **Pick the ticket.** If the attorney named one, use it. Otherwise take the
+   lowest-numbered frontier ticket (open, unclaimed, all blockers resolved).
+   **Claim it first**: set `claimed-in` to an ISO timestamp before any work.
+   If the ticket is already claimed: refuse and show the frontier.
+3. **Resolve by type:**
+   - **research (AFK)**: researcher agent + MCP in standard priority order; memo in
+     `assets/`; every citation via `swiss-caselaw:cite` (R1), quotations verbatim (R2);
+     privacy pre-check per the map's mode and `classifier`.
+   - **grilling (HITL)**: conversation with the attorney, one question at a time.
+     Client facts, priorities, risk appetite — **never answer for the human**.
+   - **prototype (HITL)**: a cheap concrete artifact to react to — outline of the
+     Klageschrift, rough clause structure — linked from `assets/`.
+   - **task (HITL/AFK)**: a precise checklist handed to the attorney/client, or driven
+     alone where possible. Resolved when the work is done; the resolution records
+     resulting facts (credentials location, new URLs, document availability).
+4. **Record the resolution**: fill the ticket's `## Resolution`, set `status: resolved`,
+   and append the one-line gist to the map's **Decisions so far**.
+5. **Maintain the map**:
+   - Graduate newly-sharp fog into tickets (create-then-wire), clearing each graduated
+     patch from **Not yet specified**.
+   - If the decision reveals a ticket sits beyond the destination: `status: ruled-out`
+     plus one line in **Out of scope**.
+   - If the decision invalidates other tickets, update or delete them.
+   - Set map `status: working` if it was still `charting`.
+6. **Check for handoff.** If the frontier is empty AND **Not yet specified** is empty:
+   set `status: ready-for-handoff`, then emit the **handoff pack** — destination +
+   Decisions so far + linked assets — and route to `/legal-5step` or the orchestrator
+   (ask the attorney which). With `--gate`, first build the Goal Record via the
+   `/legal-goal` conventions and show it for confirmation. After delivery set
+   `status: handed-off`.
+   Otherwise stop with the resolution summary and the remaining frontier (by name).
+
+## Working Rules
+
+- **One ticket per invocation** — research tickets are the only exception and may be
+  batched.
+- **Honest termination**: never present an unresolved map as clear. Dead map (fog
+  non-empty, nothing graduatable, no open tickets) → surface to the attorney: the
+  destination needs redrawing or external input is missing (a `task` ticket).
+- Refer to tickets by name in everything the attorney reads.
+- The human-in-the-loop rule applies: the map never files, sends, signs, or transmits
+  anything.
+
+## Plugin Scope Constraint
+
+For all ticket work, use **exclusively** BetterCallClaude agents, skills, and MCP
+servers. Do not delegate legal work to generic or external skills, agents, or tools
+outside this plugin.
+
+## User Query
+
+$ARGUMENTS

--- a/bettercallclaude/commands/legal-way.md
+++ b/bettercallclaude/commands/legal-way.md
@@ -84,7 +84,8 @@ in chat the resolution summary and the updated frontier. See `skills/shared/SKIL
      plus one line in **Out of scope**.
    - If the decision invalidates other tickets, update or delete them.
    - Set map `status: working` if it was still `charting`.
-6. **Check for handoff.** If the frontier is empty AND **Not yet specified** is empty:
+6. **Check for handoff.** If every ticket is `resolved` or `ruled-out` (a claimed
+   ticket in another session still counts as open) AND **Not yet specified** is empty:
    set `status: ready-for-handoff`, then emit the **handoff pack** — destination +
    Decisions so far + linked assets — and route to `/legal-5step` or the orchestrator
    (ask the attorney which). With `--gate`, first build the Goal Record via the

--- a/bettercallclaude/commands/legal-way.md
+++ b/bettercallclaude/commands/legal-way.md
@@ -52,6 +52,9 @@ in chat the resolution summary and the updated frontier. See `skills/shared/SKIL
 
 ## Pre-Flight Checks
 
+0. **List mode.** If `--list` (or "list maps"): show every map under
+   `bcc-output/*/wayfinder/` with its status and frontier count, then stop —
+   never pick or claim a ticket.
 1. **Map exists.** If none found: `ERROR: No wayfinder map found. Run /bettercallclaude:legal-chart first.`
 2. **Map not handed off.** If `status: handed-off`, show the map summary and stop — the matter is in execution.
 3. **Privacy mode loaded** from map frontmatter; `classifier` respected without re-probing.

--- a/bettercallclaude/commands/legal-way.md
+++ b/bettercallclaude/commands/legal-way.md
@@ -47,7 +47,7 @@ the map, and hand off when the route is clear.
 - "con gate" or "with gate" → `--gate`
 
 **Output convention**: update the ticket file and `map.md` in place under
-`bcc-output/<matter>/wayfinder/`; write research memos and prototypes to `assets/`. Give
+`bcc-output/YYYY-MM-DD-<slug>/wayfinder/`; write research memos and prototypes to `assets/`. Give
 in chat the resolution summary and the updated frontier. See `skills/shared/SKILL.md`.
 
 ## Pre-Flight Checks
@@ -61,7 +61,7 @@ in chat the resolution summary and the updated frontier. See `skills/shared/SKIL
 1. **Load the map** — the low-res view: Destination, Notes, Decisions so far, fog,
    Out of scope. Do not open every ticket body; zoom into related tickets on demand.
 2. **Pick the ticket.** If the attorney named one, use it. Otherwise take the
-   lowest-numbered frontier ticket (open, unclaimed, all blockers resolved).
+   lowest-numbered frontier ticket (open, unclaimed, all blockers resolved or ruled out).
    **Claim it first**: set `claimed-in` to an ISO timestamp before any work.
    If the ticket is already claimed: refuse and show the frontier.
 3. **Resolve by type:**

--- a/bettercallclaude/commands/version.md
+++ b/bettercallclaude/commands/version.md
@@ -22,7 +22,7 @@ Output the following formatted block:
 ======================================================
   BetterCallClaude - Swiss Legal Intelligence Plugin
 ======================================================
-  Version:      4.9.6
+  Version:      4.10.0
   Format:       Claude Code Plugin (Cowork Desktop)
   Author:       Federico Cesconi
   License:      AGPL-3.0

--- a/bettercallclaude/skills/legal-wayfinder/SKILL.md
+++ b/bettercallclaude/skills/legal-wayfinder/SKILL.md
@@ -1,0 +1,184 @@
+---
+name: legal-wayfinder
+description: "Decision-map decomposition for legal matters too big or too foggy for one session. Charts a map (destination, decisions so far, fog, out-of-scope) plus decision tickets under bcc-output/<matter>/wayfinder/, then works tickets one at a time until the route to the deliverable is clear, then hands off to execution. Trigger when: charting a big legal matter (/legal-chart), working the next decision ticket (/legal-way), or a briefing is too foggy for a static execution plan. Do NOT trigger for: normal matters that fit /briefing or /legal-5step, quality-gate loops (legal-goal / legal-loop), or single-question research."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_bettercallclaude_bge-search__search_bge
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
+  - mcp__plugin_bettercallclaude_fedlex-sparql__search_legislation
+  - mcp__plugin_bettercallclaude_fedlex-sparql__get_article
+  - mcp__plugin_bettercallclaude_swiss-caselaw__search_decisions
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_leading_cases
+  - mcp__plugin_bettercallclaude_swiss-caselaw__cite
+  - mcp__plugin_bettercallclaude_legal-citations__validate_citation
+  - mcp__plugin_bettercallclaude_ollama__ollama_check_status
+  - mcp__plugin_bettercallclaude_ollama__ollama_classify_privacy
+---
+
+# Legal Wayfinder — Decision Maps for Big Legal Matters
+
+A big legal matter arrives wrapped in fog: the route from intake to deliverable is not
+visible yet. Wayfinding finds that route by resolving **decisions** — not by executing
+work slices. The map is the plan; execution happens only after handoff.
+
+**Plan, don't do.** Every ticket resolves a decision. Supporting memos and prototypes are
+linked as assets, but no client deliverable is drafted inside the map. A matter may
+override this in the map's **Notes** (carrying execution into the map); absent that,
+produce decisions, not deliverables.
+
+**Refer by name.** In everything the attorney reads, refer to a ticket by its title,
+never a bare id. Ids ride inside the linked name: `[Limitation period open?](tickets/t01-limitation-period-open.md)`.
+
+## Storage
+
+Everything lives inside the matter folder — never in memory keys, never synced anywhere:
+
+```
+bcc-output/YYYY-MM-DD-<slug>/wayfinder/
+  map.md
+  tickets/
+    t01-limitation-period-open.md
+    t02-forum-choice-zh-or-federal.md
+  assets/          ← research memos, prototype outlines linked from tickets
+```
+
+## The Map (`map.md`)
+
+```markdown
+---
+matter: <slug>
+status: charting | working | ready-for-handoff | handed-off
+privacy-mode: strict | balanced | cloud
+classifier: ollama | none
+jurisdiction: federal | <canton>
+language: DE | FR | IT | EN
+---
+
+## Destination
+<1–2 lines: the deliverable this matter is finding its way to. Fixes scope;
+every session orients to it before choosing a ticket.>
+
+## Notes
+<skills to consult (swiss-legal-research, privacy-routing, swiss-citation-formats),
+standing preferences. Per-matter execution override is expressed here if needed.>
+
+## Decisions so far
+<!-- index, one line per resolved ticket: gist + link; never restate the detail -->
+
+## Not yet specified
+<!-- fog: in-scope questions you can sense but cannot phrase sharply yet -->
+
+## Out of scope
+<!-- work consciously ruled beyond the destination + why; never graduates -->
+```
+
+The map is an **index, not a store**: a decision lives in exactly one place — its
+ticket. The map gists and links.
+
+## Tickets (`tickets/tXX-<slug>.md`)
+
+```markdown
+---
+id: t01
+title: Limitation period open?
+type: research
+status: open
+blocked-by: []
+claimed-in: ""
+---
+
+## Question
+<the decision this ticket resolves, sized to one agent session>
+
+## Resolution
+<filled on close: the decision + evidence; assets linked, never pasted>
+```
+
+### Ticket types
+
+| Type | Mode | Resolves | Rules |
+|------|------|----------|-------|
+| `research` | AFK | A fact a decision waits on (precedent, statute, deadline) | Researcher agent + MCP servers; memo in `assets/`; R1 (citations only via `swiss-caselaw:cite`) and R2 (verbatim quotations) enforced |
+| `grilling` | HITL | Client facts, priorities, risk appetite | Conversation with the attorney, one question at a time. **Never answer for the human** — an agent that answers its own grilling questions has broken the ticket |
+| `prototype` | HITL | "How should it look/behave" | Cheap concrete artifact to react to — outline of the Klageschrift, rough clause structure — linked from `assets/` |
+| `task` | HITL or AFK | Work that unblocks a decision (gather contract file, obtain court records) | Precise checklist for attorney/client, or driven alone where possible; resolution records what was done and resulting facts later tickets depend on |
+
+## Frontier and claiming
+
+The **frontier** is every ticket with `status: open`, empty `claimed-in`, and all
+`blocked-by` tickets `status: resolved`. `/legal-way` picks the lowest-numbered frontier
+ticket unless the attorney names one. Claim by setting `claimed-in` to a session stamp
+(ISO date + time) **before any work**; refuse a ticket already claimed. One ticket per
+`/legal-way` invocation — research tickets are the only exception (they may be batched
+or fired in parallel by `/legal-chart`).
+
+## Fog of war
+
+The map is deliberately incomplete. Beyond the live tickets lies fog — questions you can
+sense but cannot phrase sharply yet because they hang on open decisions. The test:
+
+- **Ticket** when the question is already sharp — even if blocked.
+- **Not yet specified** when it is not yet phrasable that sharply. Never pre-slice fog
+  into ticket-sized pieces; one patch may graduate into several tickets, or none.
+
+Resolving a ticket graduates whatever it made sharp: create new tickets (create-then-wire
+blocking edges in a second pass), and clear each graduated patch from **Not yet
+specified** so it lives only as its ticket.
+
+## Out of scope
+
+Fog gathers only toward the destination; work beyond it is out of scope and never
+graduates. When a live ticket turns out to sit past the destination, set it
+`status: ruled-out` (not resolved) and add one line to **Out of scope**: gist + why +
+link. It stays out of **Decisions so far** — a scope boundary is not a step on the route.
+
+## Edge cases
+
+- **Outgrown ticket**: if resolving a ticket sprawls beyond one session's worth, split
+  it — create the successor tickets plus any fresh fog, and close the original
+  `resolved` with a pointer to its children in the Resolution.
+- **Stale research**: a research resolution in fast-moving law may note
+  `revalidate: true`. Re-open it only by creating a fresh ticket referencing the old
+  one — never by editing a recorded resolution.
+
+## Privacy (Anwaltsgeheimnis)
+
+The map's `privacy-mode` governs every ticket; the PreToolUse hook keeps guarding writes
+regardless. `classifier` is probed once at chart time (`ollama_check_status`) — never
+re-probed per ticket. Degradation follows the `privacy-routing` decision matrix:
+
+| Content | classifier: ollama | classifier: none |
+|---------|--------------------|------------------|
+| PUBLIC | cloud preferred | cloud OK |
+| CONFIDENTIAL | local preferred | anonymize → cloud + warning |
+| PRIVILEGED / undeterminable (strict) | local required | no automated clear: stay local-only, or ask the attorney directly before any cloud call |
+
+A research ticket touching privileged facts with no classifier does not hard-fail the
+map: convert to conversation — ask the attorney to reformulate the question in anonymous
+terms, then proceed as CONFIDENTIAL. Fail closed; never "just send it".
+
+## Handoff
+
+When `/legal-way` resolves the last ticket and graduates the last fog, set
+`status: ready-for-handoff` and — instead of stopping — emit a **handoff pack**:
+destination + Decisions so far + linked assets, shaped to feed the orchestrator's
+Briefing-Sourced Execution protocol. Route to `/legal-5step` or the orchestrator. With
+`--gate`, pre-build a `/legal-goal` record so execution runs under the worker–evaluator
+loop from day one. Set `status: handed-off` once the pack is delivered.
+
+## Honest termination
+
+Never present an unresolved map as clear. If the map is dead — fog non-empty, nothing
+graduatable, no open tickets — surface it to the attorney: the destination needs
+redrawing or external input is missing (which is itself a `task` ticket).
+
+## Plugin Scope Constraint
+
+For all wayfinding tasks, use **exclusively** BetterCallClaude agents, skills, and MCP
+servers. Do not delegate legal work to generic or external skills, agents, or tools
+outside this plugin.

--- a/bettercallclaude/skills/legal-wayfinder/SKILL.md
+++ b/bettercallclaude/skills/legal-wayfinder/SKILL.md
@@ -164,7 +164,9 @@ terms, then proceed as CONFIDENTIAL. Fail closed; never "just send it".
 
 ## Handoff
 
-When `/legal-way` resolves the last ticket and graduates the last fog, set
+Hand off only when every ticket is `resolved` or `ruled-out` and the fog is empty.
+A claimed ticket still counts as open — in-flight work in another session blocks
+handoff. When `/legal-way` reaches that state, set
 `status: ready-for-handoff` and — instead of stopping — emit a **handoff pack**:
 destination + Decisions so far + linked assets, shaped to feed the orchestrator's
 Briefing-Sourced Execution protocol. Route to `/legal-5step` or the orchestrator. With

--- a/bettercallclaude/skills/legal-wayfinder/SKILL.md
+++ b/bettercallclaude/skills/legal-wayfinder/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: legal-wayfinder
-description: "Decision-map decomposition for legal matters too big or too foggy for one session. Charts a map (destination, decisions so far, fog, out-of-scope) plus decision tickets under bcc-output/<matter>/wayfinder/, then works tickets one at a time until the route to the deliverable is clear, then hands off to execution. Trigger when: charting a big legal matter (/legal-chart), working the next decision ticket (/legal-way), or a briefing is too foggy for a static execution plan. Do NOT trigger for: normal matters that fit /briefing or /legal-5step, quality-gate loops (legal-goal / legal-loop), or single-question research."
+description: "Decision-map decomposition for legal matters too big or too foggy for one session. Charts a map (destination, decisions so far, fog, out-of-scope) plus decision tickets under bcc-output/YYYY-MM-DD-<slug>/wayfinder/, then works tickets one at a time until the route to the deliverable is clear, then hands off to execution. Trigger when: charting a big legal matter (/legal-chart), working the next decision ticket (/legal-way), or a briefing is too foggy for a static execution plan. Do NOT trigger for: normal matters that fit /briefing or /legal-5step, quality-gate loops (legal-goal / legal-loop), or single-question research."
 tools:
   - Read
   - Grep
@@ -111,7 +111,7 @@ claimed-in: ""
 ## Frontier and claiming
 
 The **frontier** is every ticket with `status: open`, empty `claimed-in`, and all
-`blocked-by` tickets `status: resolved`. `/legal-way` picks the lowest-numbered frontier
+`blocked-by` tickets `status: resolved` or `ruled-out`. `/legal-way` picks the lowest-numbered frontier
 ticket unless the attorney names one. Claim by setting `claimed-in` to a session stamp
 (ISO date + time) **before any work**; refuse a ticket already claimed. One ticket per
 `/legal-way` invocation — research tickets are the only exception (they may be batched

--- a/docs/design/2026-08-19-legal-wayfinder-design.md
+++ b/docs/design/2026-08-19-legal-wayfinder-design.md
@@ -1,0 +1,273 @@
+# Legal Wayfinder — Decision-Map Decomposition for Big Legal Matters
+
+**Design Specification v1.0**
+**Framework**: BetterCallClaude Legal Intelligence
+**Status**: Approved design (brainstorming complete, implementation not started)
+**Date**: 2026-08-19
+
+---
+
+## 🎯 Design Objectives
+
+### Core Mission
+
+Bring wayfinder-style task decomposition into BetterCallClaude: chart a legal matter too big
+or too foggy for a single session as a **decision map** — a persistent file-based artifact
+plus **decision tickets** — and work the tickets one at a time until the way to the
+destination is clear, then hand off to the existing execution machinery.
+
+Wayfinder's core insight, adapted to legal work: a big matter is wrapped in fog — the route
+from intake to deliverable isn't visible yet. Wayfinding finds that way by resolving
+**decisions** ("is the limitation period open?", "forum ZH or federal?"), not by executing
+build slices. Decisions clear the fog; only when the route is clear does execution begin.
+
+### Goals
+
+1. **Chart/work split** — decompose a big matter into decision tickets in one session
+   (`/legal-chart`), work them one at a time in later sessions (`/legal-way`).
+2. **Fog-of-war replanning** — the plan is not fixed upfront; tickets graduate from fog
+   only when earlier decisions make them sharp.
+3. **Decision-first gate** — open legal questions are resolved as decisions *before* any
+   execution stage runs; then the decision trail hands off to the existing machinery.
+4. **Durable cross-session state** — the map lives as files in the matter folder, not in
+   memory keys; resumable, auditable, never synced anywhere.
+
+### Non-Goals
+
+- ❌ Not a replacement for `/briefing` on normal matters (static plans remain the default)
+- ❌ Not an execution engine — the map decides; `/legal-5step` / orchestrator execute
+- ❌ No issue-tracker backend (GitHub Issues) — privacy rules this out for v1
+- ❌ No helper script / DAG validator in v1 (markdown discipline suffices at 5–20 tickets)
+- ❌ No automatic staleness re-validation of research resolutions
+
+---
+
+## 📐 Decisions Settled in Brainstorming
+
+| # | Question | Decision |
+|---|----------|----------|
+| 1 | Primary job | All four goals above (full wayfinder adaptation) |
+| 2 | Map storage | Local files in `bcc-output/<matter>/wayfinder/` (privacy-first) |
+| 3 | User surface | Two new commands `/legal-chart` + `/legal-way`; `/briefing` gains only a routing rule |
+| 4 | Decide vs do | Strict: tickets resolve decisions only; deliverables happen after handoff (per-matter override via map Notes possible) |
+| 5 | Ticket types v1 | All four: `research` (AFK), `grilling` (HITL), `prototype` (HITL), `task` (HITL/AFK) |
+| 6 | Implementation | Pure markdown discipline + shared skill module (Approach A); no new code |
+
+---
+
+## 🏗️ Components
+
+### New Files
+
+| File | Role |
+|------|------|
+| `skills/legal-wayfinder/SKILL.md` | Canonical protocol: map format, ticket types, frontier/fog rules, handoff. Single source of truth shared by both commands (the `swiss-legal-research` pattern) |
+| `commands/legal-chart.md` | Chart mode: decompose a big matter into map + tickets (one session, resolves nothing) |
+| `commands/legal-way.md` | Work mode: resolve one ticket per invocation, maintain the map, detect handoff |
+
+### Touched Files
+
+| File | Change |
+|------|--------|
+| `commands/briefing.md` + briefing-coordinator agent | Routing rule: high complexity or visible fog → offer `/legal-chart` instead of a static plan |
+| `README.md` (repo + plugin) | Command count 27→29, skill count 16→17, feature mention |
+| `CHANGELOG.md` | New entry |
+| `.claude-plugin/plugin.json`, `AGENTS.md` | Version bump / counts refresh |
+
+### Storage Layout
+
+```
+bcc-output/YYYY-MM-DD-<slug>/wayfinder/
+  map.md
+  tickets/
+    t01-limitation-period-open.md
+    t02-forum-choice-zh-or-federal.md
+  assets/          ← research memos, prototype outlines linked from tickets
+```
+
+Everything lives inside the matter folder. Nothing is written to memory keys, plugin state,
+or any external service.
+
+---
+
+## 📄 File Formats
+
+### Map (`map.md`)
+
+```markdown
+---
+matter: <slug>
+status: charting | working | ready-for-handoff | handed-off
+privacy-mode: strict | balanced | cloud
+classifier: ollama | none          # probed at chart time, never re-probed per ticket
+jurisdiction: federal | <canton>
+language: DE | FR | IT | EN
+---
+
+## Destination
+<1–2 lines: the deliverable this matter is finding its way to — e.g. "file-ready
+Klageschrift, forum chosen, limitation cleared". Fixes scope; every session orients
+to it before choosing a ticket.>
+
+## Notes
+<skills to consult (swiss-legal-research, privacy-routing, swiss-citation-formats),
+standing preferences. Per-matter "plan, don't do" override is expressed here if needed.>
+
+## Decisions so far
+<!-- index, one line per resolved ticket: enough to judge relevance, link holds detail -->
+- [Limitation period open?](tickets/t01-limitation-period-open.md) — yes; Art. 77 CO absolute deadline runs to 2027-03
+
+## Not yet specified
+<!-- fog: in-scope questions you can sense but cannot phrase sharply yet; graduates
+     as the frontier advances. Never pre-sliced into ticket-sized pieces. -->
+
+## Out of scope
+<!-- work consciously ruled beyond the destination + why; never graduates -->
+```
+
+The map is an **index, not a store**: a decision lives in exactly one place — its ticket —
+so the map gists and links, never restates.
+
+### Ticket (`tickets/tXX-<slug>.md`)
+
+```markdown
+---
+id: t01
+title: Limitation period open?
+type: research          # research | grilling | prototype | task
+status: open            # open | resolved | ruled-out
+blocked-by: []          # ticket ids that must be resolved first
+claimed-in: ""          # session stamp set by /legal-way when claiming
+---
+
+## Question
+<the decision this ticket resolves, sized to one agent session>
+
+## Resolution            <!-- filled on close -->
+<the decision + evidence; assets linked, never pasted>
+```
+
+**Naming**: refer to tickets by title in everything the attorney reads, never bare ids.
+Ids ride inside the linked name.
+
+### Frontier
+
+The **frontier** is every ticket with `status: open`, an empty `claimed-in`, and all
+`blocked-by` tickets `status: resolved`. The model computes it by reading the files —
+sufficient at legal-matter scale (5–20 tickets).
+
+---
+
+## 🔄 Command Flows
+
+### `/legal-chart <matter>` — one session, charts only
+
+1. **Name the destination.** Grill the attorney (one question at a time) to pin the
+   deliverable. The destination fixes scope, so it is settled first.
+2. **Breadth-first grill.** Fan out across the whole matter — jurisdiction, parties'
+   positions, limitation, forum, evidence availability, client risk appetite — never deep
+   on any one thread.
+   **Early exit:** if no fog surfaces, the matter fits a normal briefing — stop and
+   suggest `/briefing` or `/legal-5step` instead of creating a map.
+3. **Probe classifier capability** (`ollama_check_status`) and create the map
+   (`status: charting`, fog sketched into *Not yet specified*).
+4. **Create the tickets that are sharp now**, then wire `blocked-by` edges in a second
+   pass (files need ids before they can reference each other).
+5. **Fire research tickets in parallel** — researcher agent via subagents, MCP servers in
+   standard priority order, R1/R2 enforced, privacy pre-check per the map's privacy mode.
+   Memos land in `assets/`.
+6. **Stop.** Charting resolves nothing itself.
+
+### `/legal-way [ticket]` — one ticket per invocation
+
+1. **Load the map** (the low-res view, not every ticket body). If several maps exist in
+   the working folder, list them and ask which.
+2. **Pick the ticket** — the named one, else the lowest-numbered frontier ticket. **Claim it**
+   (`claimed-in` stamp) before any work; refuse tickets already claimed.
+3. **Resolve by type:**
+   - **research** (AFK): researcher agent + MCP; memo in `assets/`; every citation via
+     `swiss-caselaw:cite`, never constructed by hand (R1); quotations verbatim (R2).
+   - **grilling** (HITL): conversation with the attorney, one question at a time —
+     client facts, priorities, risk appetite. The agent never answers for the human.
+   - **prototype** (HITL): a cheap concrete artifact to react to — outline of the
+     Klageschrift, rough clause structure — linked from `assets/`.
+   - **task** (HITL/AFK): a precise checklist handed to attorney/client (gather contract
+     file, obtain court records) or driven alone where possible; resolved when done,
+     recording resulting facts later tickets depend on.
+4. **Record**: fill `## Resolution`, set `status: resolved`, append the one-line gist to
+   the map's *Decisions so far*.
+5. **Maintain the map**: graduate newly-sharp fog into tickets (create-then-wire); rule
+   mis-scoped tickets `ruled-out` with a line in *Out of scope*; update or delete tickets
+   the decision invalidates.
+6. **Stop.** Research tickets are exempt from the one-per-invocation rule.
+
+### Handoff
+
+The `/legal-way` invocation that resolves the last ticket and graduates the last fog sets
+`status: ready-for-handoff` and — instead of stopping — emits a **handoff pack**
+(destination + Decisions so far + linked assets) and routes to `/legal-5step` or the
+orchestrator. The pack is shaped to feed the
+orchestrator's existing *Briefing-Sourced Execution* protocol — no orchestrator changes
+required. Optional `--gate` pre-builds a `/legal-goal` record so execution runs under the
+worker–evaluator loop from day one.
+
+---
+
+## 🔌 Integration
+
+- **Briefing routing**: when the coordinator's complexity score is high, or the would-be
+  plan contains decisions depending on other open decisions, it offers:
+  *"This matter is too foggy for a static plan — chart it instead?"* → `/legal-chart`.
+  Nothing else in `/briefing` changes.
+- **Natural-language equivalents** (Italian/English, like sibling commands):
+  "traccia la mappa" / "chart the matter" → `/legal-chart`;
+  "prossima tessera" / "next ticket" → `/legal-way`.
+- **Plugin scope constraint** applies: tickets resolve via BetterCallClaude agents,
+  skills, and MCP servers exclusively.
+
+---
+
+## 🔒 Privacy (Anwaltsgeheimnis)
+
+- Map, tickets, and assets live **only** in the local matter folder — never in memory
+  keys, never synced anywhere. Same privilege posture as 5-step outputs.
+- `privacy-mode` in map frontmatter governs every ticket: `strict` → automated
+  pre-check before any cloud MCP call; `balanced` → privileged content routed local-only,
+  cloud receives sanitised content. The PreToolUse hook keeps guarding writes regardless.
+- **No-ollama degradation** (map `classifier: none`), following the existing
+  `privacy-routing` decision matrix — fail-closed, never "just send it":
+
+  | Content | Ollama available | Ollama missing (`classifier: none`) |
+  |---------|------------------|-------------------------------------|
+  | PUBLIC | cloud preferred | cloud OK |
+  | CONFIDENTIAL | local preferred | anonymize → cloud + warning |
+  | PRIVILEGED / undeterminable (strict) | local required | no automated clear: stay local-only, or ask the attorney directly (HITL confirm) before any cloud call |
+
+- A research ticket touching privileged facts does not hard-fail the map when no
+  classifier exists: it converts to conversation — ask the attorney to reformulate the
+  question in anonymous terms (standard anonymization guidance), then proceed as
+  CONFIDENTIAL.
+
+---
+
+## 🧭 Edge Cases
+
+- **Concurrent sessions**: `claimed-in` stamp; `/legal-way` refuses an already-claimed ticket.
+- **Multiple maps** in one working folder: list and ask.
+- **Dead map** (fog non-empty, nothing graduatable, no open tickets): surface to the
+  attorney — the destination needs redrawing or external input is missing (→ `task` ticket).
+- **Outgrown ticket**: split into new tickets + fog; close the original with a pointer.
+- **Stale research**: ticket Notes may carry a re-validate flag; no automatic machinery in v1.
+- **Per-matter execution override**: map Notes may explicitly carry execution into
+  tickets (wayfinder's override rule); absent that, strict decide-then-hand-off applies.
+
+---
+
+## ✅ Validation & Rollout
+
+- Pure markdown — CI frontmatter validation covers the new command and skill files
+  automatically; no unit tests (consistent with sibling commands).
+- README counts: 27→29 commands, 16→17 skills; CHANGELOG entry; version bump;
+  AGENTS.md counts refreshed.
+- Rollout: one release, no feature flag (new commands are additive and discoverable
+  via `/help`).

--- a/docs/project-management/2026-08-19-legal-wayfinder-plan.md
+++ b/docs/project-management/2026-08-19-legal-wayfinder-plan.md
@@ -1,0 +1,672 @@
+# Legal Wayfinder Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship `/legal-chart` + `/legal-way` commands and the `legal-wayfinder` skill so big legal matters can be decomposed into decision maps and worked ticket-by-ticket, per `docs/design/2026-08-19-legal-wayfinder-design.md`.
+
+**Architecture:** Pure markdown discipline — no new code. A skill module holds the canonical protocol (map/ticket formats, frontier, fog, privacy, handoff); two thin command gateways invoke it. Map and tickets are files under `bcc-output/<matter>/wayfinder/`. `/briefing` gains one routing rule for foggy high-complexity matters.
+
+**Tech Stack:** Claude Code plugin markdown (YAML frontmatter + prompt bodies), existing BCC MCP servers, existing CI structure validation.
+
+## Global Constraints
+
+- All new files live under `bettercallclaude/` (the plugin directory that gets packaged).
+- Frontmatter style: `---` fenced YAML with `description` (commands) or `name` + `description` (skills); kebab-case filenames.
+- Commands end with `## User Query` section containing `$ARGUMENTS`.
+- Every user-facing file must include the Plugin Scope Constraint paragraph: "For all … use **exclusively** BetterCallClaude agents, skills, and MCP servers."
+- No code, no scripts, no new dependencies (spec decision #6, Approach A).
+- Version bump: 4.9.6 → 4.10.0 (feature release). Counts: 27→29 commands, 16→17 skills.
+- Privacy behavior must match `skills/privacy-routing/SKILL.md` decision matrix — fail-closed, never "just send it".
+
+---
+
+### Task 1: Skill module — `legal-wayfinder`
+
+**Files:**
+- Create: `bettercallclaude/skills/legal-wayfinder/SKILL.md`
+
+**Interfaces:**
+- Produces: the canonical protocol both commands reference — map frontmatter fields (`matter`, `status: charting|working|ready-for-handoff|handed-off`, `privacy-mode`, `classifier: ollama|none`, `jurisdiction`, `language`), ticket frontmatter fields (`id`, `title`, `type: research|grilling|prototype|task`, `status: open|resolved|ruled-out`, `blocked-by`, `claimed-in`), storage layout `bcc-output/YYYY-MM-DD-<slug>/wayfinder/{map.md,tickets/,assets/}`.
+
+- [ ] **Step 1: Verify the skill does not exist yet (the failing check)**
+
+Run: `test -f bettercallclaude/skills/legal-wayfinder/SKILL.md && echo EXISTS || echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Create the skill directory and file**
+
+```bash
+mkdir -p bettercallclaude/skills/legal-wayfinder
+```
+
+Then write `bettercallclaude/skills/legal-wayfinder/SKILL.md` with exactly this content:
+
+````markdown
+---
+name: legal-wayfinder
+description: "Decision-map decomposition for legal matters too big or too foggy for one session. Charts a map (destination, decisions so far, fog, out-of-scope) plus decision tickets under bcc-output/<matter>/wayfinder/, then works tickets one at a time until the route to the deliverable is clear, then hands off to execution. Trigger when: charting a big legal matter (/legal-chart), working the next decision ticket (/legal-way), or a briefing is too foggy for a static execution plan. Do NOT trigger for: normal matters that fit /briefing or /legal-5step, quality-gate loops (legal-goal / legal-loop), or single-question research."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_bettercallclaude_bge-search__search_bge
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
+  - mcp__plugin_bettercallclaude_fedlex-sparql__search_legislation
+  - mcp__plugin_bettercallclaude_fedlex-sparql__get_article
+  - mcp__plugin_bettercallclaude_swiss-caselaw__search_decisions
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_leading_cases
+  - mcp__plugin_bettercallclaude_swiss-caselaw__cite
+  - mcp__plugin_bettercallclaude_legal-citations__validate_citation
+  - mcp__plugin_bettercallclaude_ollama__ollama_check_status
+  - mcp__plugin_bettercallclaude_ollama__ollama_classify_privacy
+---
+
+# Legal Wayfinder — Decision Maps for Big Legal Matters
+
+A big legal matter arrives wrapped in fog: the route from intake to deliverable is not
+visible yet. Wayfinding finds that route by resolving **decisions** — not by executing
+work slices. The map is the plan; execution happens only after handoff.
+
+**Plan, don't do.** Every ticket resolves a decision. Supporting memos and prototypes are
+linked as assets, but no client deliverable is drafted inside the map. A matter may
+override this in the map's **Notes** (carrying execution into the map); absent that,
+produce decisions, not deliverables.
+
+**Refer by name.** In everything the attorney reads, refer to a ticket by its title,
+never a bare id. Ids ride inside the linked name: `[Limitation period open?](tickets/t01-limitation-period-open.md)`.
+
+## Storage
+
+Everything lives inside the matter folder — never in memory keys, never synced anywhere:
+
+```
+bcc-output/YYYY-MM-DD-<slug>/wayfinder/
+  map.md
+  tickets/
+    t01-limitation-period-open.md
+    t02-forum-choice-zh-or-federal.md
+  assets/          ← research memos, prototype outlines linked from tickets
+```
+
+## The Map (`map.md`)
+
+```markdown
+---
+matter: <slug>
+status: charting | working | ready-for-handoff | handed-off
+privacy-mode: strict | balanced | cloud
+classifier: ollama | none
+jurisdiction: federal | <canton>
+language: DE | FR | IT | EN
+---
+
+## Destination
+<1–2 lines: the deliverable this matter is finding its way to. Fixes scope;
+every session orients to it before choosing a ticket.>
+
+## Notes
+<skills to consult (swiss-legal-research, privacy-routing, swiss-citation-formats),
+standing preferences. Per-matter execution override is expressed here if needed.>
+
+## Decisions so far
+<!-- index, one line per resolved ticket: gist + link; never restate the detail -->
+
+## Not yet specified
+<!-- fog: in-scope questions you can sense but cannot phrase sharply yet -->
+
+## Out of scope
+<!-- work consciously ruled beyond the destination + why; never graduates -->
+```
+
+The map is an **index, not a store**: a decision lives in exactly one place — its
+ticket. The map gists and links.
+
+## Tickets (`tickets/tXX-<slug>.md`)
+
+```markdown
+---
+id: t01
+title: Limitation period open?
+type: research
+status: open
+blocked-by: []
+claimed-in: ""
+---
+
+## Question
+<the decision this ticket resolves, sized to one agent session>
+
+## Resolution
+<filled on close: the decision + evidence; assets linked, never pasted>
+```
+
+### Ticket types
+
+| Type | Mode | Resolves | Rules |
+|------|------|----------|-------|
+| `research` | AFK | A fact a decision waits on (precedent, statute, deadline) | Researcher agent + MCP servers; memo in `assets/`; R1 (citations only via `swiss-caselaw:cite`) and R2 (verbatim quotations) enforced |
+| `grilling` | HITL | Client facts, priorities, risk appetite | Conversation with the attorney, one question at a time. **Never answer for the human** — an agent that answers its own grilling questions has broken the ticket |
+| `prototype` | HITL | "How should it look/behave" | Cheap concrete artifact to react to — outline of the Klageschrift, rough clause structure — linked from `assets/` |
+| `task` | HITL or AFK | Work that unblocks a decision (gather contract file, obtain court records) | Precise checklist for attorney/client, or driven alone where possible; resolution records what was done and resulting facts later tickets depend on |
+
+## Frontier and claiming
+
+The **frontier** is every ticket with `status: open`, empty `claimed-in`, and all
+`blocked-by` tickets `status: resolved`. `/legal-way` picks the lowest-numbered frontier
+ticket unless the attorney names one. Claim by setting `claimed-in` to a session stamp
+(ISO date + time) **before any work**; refuse a ticket already claimed. One ticket per
+`/legal-way` invocation — research tickets are the only exception (they may be batched
+or fired in parallel by `/legal-chart`).
+
+## Fog of war
+
+The map is deliberately incomplete. Beyond the live tickets lies fog — questions you can
+sense but cannot phrase sharply yet because they hang on open decisions. The test:
+
+- **Ticket** when the question is already sharp — even if blocked.
+- **Not yet specified** when it is not yet phrasable that sharply. Never pre-slice fog
+  into ticket-sized pieces; one patch may graduate into several tickets, or none.
+
+Resolving a ticket graduates whatever it made sharp: create new tickets (create-then-wire
+blocking edges in a second pass), and clear each graduated patch from **Not yet
+specified** so it lives only as its ticket.
+
+## Out of scope
+
+Fog gathers only toward the destination; work beyond it is out of scope and never
+graduates. When a live ticket turns out to sit past the destination, set it
+`status: ruled-out` (not resolved) and add one line to **Out of scope**: gist + why +
+link. It stays out of **Decisions so far** — a scope boundary is not a step on the route.
+
+## Edge cases
+
+- **Outgrown ticket**: if resolving a ticket sprawls beyond one session's worth, split
+  it — create the successor tickets plus any fresh fog, and close the original
+  `resolved` with a pointer to its children in the Resolution.
+- **Stale research**: a research resolution in fast-moving law may note
+  `revalidate: true`. Re-open it only by creating a fresh ticket referencing the old
+  one — never by editing a recorded resolution.
+
+## Privacy (Anwaltsgeheimnis)
+
+The map's `privacy-mode` governs every ticket; the PreToolUse hook keeps guarding writes
+regardless. `classifier` is probed once at chart time (`ollama_check_status`) — never
+re-probed per ticket. Degradation follows the `privacy-routing` decision matrix:
+
+| Content | classifier: ollama | classifier: none |
+|---------|--------------------|------------------|
+| PUBLIC | cloud preferred | cloud OK |
+| CONFIDENTIAL | local preferred | anonymize → cloud + warning |
+| PRIVILEGED / undeterminable (strict) | local required | no automated clear: stay local-only, or ask the attorney directly before any cloud call |
+
+A research ticket touching privileged facts with no classifier does not hard-fail the
+map: convert to conversation — ask the attorney to reformulate the question in anonymous
+terms, then proceed as CONFIDENTIAL. Fail closed; never "just send it".
+
+## Handoff
+
+When `/legal-way` resolves the last ticket and graduates the last fog, set
+`status: ready-for-handoff` and — instead of stopping — emit a **handoff pack**:
+destination + Decisions so far + linked assets, shaped to feed the orchestrator's
+Briefing-Sourced Execution protocol. Route to `/legal-5step` or the orchestrator. With
+`--gate`, pre-build a `/legal-goal` record so execution runs under the worker–evaluator
+loop from day one. Set `status: handed-off` once the pack is delivered.
+
+## Honest termination
+
+Never present an unresolved map as clear. If the map is dead — fog non-empty, nothing
+graduatable, no open tickets — surface it to the attorney: the destination needs
+redrawing or external input is missing (which is itself a `task` ticket).
+
+## Plugin Scope Constraint
+
+For all wayfinding tasks, use **exclusively** BetterCallClaude agents, skills, and MCP
+servers. Do not delegate legal work to generic or external skills, agents, or tools
+outside this plugin.
+````
+
+- [ ] **Step 3: Run the frontmatter check (CI parity)**
+
+Run: `for skill_dir in bettercallclaude/skills/*/; do skill_file="${skill_dir}SKILL.md"; if [ ! -f "$skill_file" ]; then echo "FAIL: Missing $skill_file"; exit 1; fi; head -1 "$skill_file" | grep -q '^---$' || { echo "FAIL: $skill_file missing YAML frontmatter"; exit 1; }; done; echo ALL_OK`
+Expected: `ALL_OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bettercallclaude/skills/legal-wayfinder/SKILL.md
+git commit -m "feat: add legal-wayfinder skill (decision-map protocol)"
+```
+
+---
+
+### Task 2: Command — `/legal-chart`
+
+**Files:**
+- Create: `bettercallclaude/commands/legal-chart.md`
+
+**Interfaces:**
+- Consumes: the `legal-wayfinder` skill protocol from Task 1 (map/ticket formats, storage layout).
+- Produces: `bcc-output/YYYY-MM-DD-<slug>/wayfinder/map.md` + `tickets/*.md` with `classifier` probed and `status: charting`.
+
+- [ ] **Step 1: Verify the command does not exist yet**
+
+Run: `test -f bettercallclaude/commands/legal-chart.md && echo EXISTS || echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Write the command file**
+
+Write `bettercallclaude/commands/legal-chart.md` with exactly this content:
+
+````markdown
+---
+description: "Chart a big legal matter as a wayfinder decision map — grill the attorney breadth-first, create the map and decision tickets, fire research tickets in parallel. Planning only: charting resolves no decisions itself."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_bettercallclaude_bge-search__search_bge
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_canton
+  - mcp__plugin_bettercallclaude_fedlex-sparql__search_legislation
+  - mcp__plugin_bettercallclaude_fedlex-sparql__get_article
+  - mcp__plugin_bettercallclaude_swiss-caselaw__search_decisions
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_leading_cases
+  - mcp__plugin_bettercallclaude_swiss-caselaw__get_case_brief
+  - mcp__plugin_bettercallclaude_swiss-caselaw__cite
+  - mcp__plugin_bettercallclaude_onlinekommentar__search_commentaries
+  - mcp__plugin_bettercallclaude_ollama__ollama_check_status
+---
+
+# /legal-chart — Chart a Legal Decision Map
+
+You are invoked via `/bettercallclaude:legal-chart`. You apply the `legal-wayfinder`
+skill in full. Your sole purpose is to **chart** a big or foggy legal matter as a
+decision map: map file plus decision tickets. You resolve nothing yourself — that is
+`/legal-way`'s job.
+
+## Parameters
+
+- Query text: the matter description (free text).
+- `--privacy=<mode>`: privacy mode for the map (`strict`, `balanced`, `cloud`). Defaults to the configured mode.
+- `--lang=DE|FR|IT|EN`: map language. Defaults to auto-detect from input.
+- `--canton=XX`: cantonal jurisdiction (e.g. `--canton=ZH`). Defaults to federal.
+
+**Natural language equivalents**:
+- "traccia la mappa" or "chart the matter" → start charting
+- "matter privato" / "privacy strict" → `--privacy=strict`
+- "in tedesco" / "auf Deutsch" → `--lang=DE`
+- "giurisdizione Zurigo" / "Zurich jurisdiction" → `--canton=ZH`
+
+**Output convention**: write the map to `bcc-output/YYYY-MM-DD-<slug>/wayfinder/map.md`
+and tickets to `.../wayfinder/tickets/`. Give in chat only the map summary (destination,
+ticket list by name with types, fog count). See `skills/shared/SKILL.md`.
+
+## Charting Flow
+
+1. **Name the destination.** Grill the attorney (one question at a time) to pin the
+   deliverable — "file-ready Klageschrift", "DD report for the SPA". The destination
+   fixes scope, so it is settled first.
+2. **Breadth-first grill.** Fan out across the whole matter — jurisdiction, parties'
+   positions, limitation, forum, evidence availability, client risk appetite — never
+   deep on any one thread. Surface every open decision you can sense.
+
+   **Early exit — no fog:** if this surfaces no open decisions (the way to the
+   destination is already clear, the matter fits one execution plan), do NOT create a
+   map. Stop and tell the attorney:
+   ```
+   This matter is clear enough for direct execution — no map needed.
+   Options: /bettercallclaude:briefing (structured plan) or
+   /bettercallclaude:legal-5step (end-to-end pipeline).
+   ```
+
+3. **Probe the classifier** with `ollama_check_status` and record the result.
+4. **Create the map** (`status: charting`) with the fog sketched into *Not yet
+   specified*.
+5. **Create the tickets that are sharp now** as ticket files — then wire `blocked-by`
+   edges in a **second pass** (files need ids before they can reference each other).
+   Everything not yet phrasable stays in the fog.
+6. **Fire research tickets in parallel**: dispatch the researcher agent as subagents,
+   MCP servers in the standard priority order, R1/R2 enforced, privacy pre-check per
+   the map's privacy mode. Memos land in `assets/`. Research resolutions are recorded
+   on the tickets by those subagents.
+7. **Stop.** Report the charted map and end the session. Charting hand-resolves nothing.
+
+## Charting Rules
+
+- One session of work; never resolve a non-research ticket while charting.
+- Refer to tickets by name in everything the attorney reads.
+- Refer the attorney to `/bettercallclaude:legal-way` to work the map: *"Map charted.
+  Run `/bettercallclaude:legal-way` (or 'next ticket') to work the first ticket."*
+- If multiple maps already exist in the working folder, chart into a new dated folder —
+  never merge maps.
+
+## Plugin Scope Constraint
+
+For all charting tasks, use **exclusively** BetterCallClaude agents, skills, and MCP
+servers. Do not delegate legal work to generic or external skills, agents, or tools
+outside this plugin.
+
+## User Query
+
+$ARGUMENTS
+````
+
+- [ ] **Step 3: Run the command frontmatter check**
+
+Run: `head -1 bettercallclaude/commands/legal-chart.md | grep -q '^---$' && echo OK || echo FAIL`
+Expected: `OK`
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bettercallclaude/commands/legal-chart.md
+git commit -m "feat: add /legal-chart command (chart a legal decision map)"
+```
+
+---
+
+### Task 3: Command — `/legal-way`
+
+**Files:**
+- Create: `bettercallclaude/commands/legal-way.md`
+
+**Interfaces:**
+- Consumes: `legal-wayfinder` skill protocol (Task 1); maps produced by `/legal-chart` (Task 2).
+- Produces: resolved tickets, updated `map.md`, handoff pack routed to `/legal-5step` or the orchestrator; optionally a `/legal-goal` Goal Record with `--gate`.
+
+- [ ] **Step 1: Verify the command does not exist yet**
+
+Run: `test -f bettercallclaude/commands/legal-way.md && echo EXISTS || echo MISSING`
+Expected: `MISSING`
+
+- [ ] **Step 2: Write the command file**
+
+Write `bettercallclaude/commands/legal-way.md` with exactly this content:
+
+````markdown
+---
+description: "Work one ticket from a legal-wayfinder decision map — claim a frontier ticket, resolve it by type (research / grilling / prototype / task), record the decision, graduate newly-sharp fog, and emit the handoff pack when the map is clear."
+tools:
+  - Read
+  - Grep
+  - Glob
+  - Bash
+  - WebSearch
+  - WebFetch
+  - mcp__plugin_bettercallclaude_bge-search__search_bge
+  - mcp__plugin_bettercallclaude_bge-search__get_bge_decision
+  - mcp__plugin_bettercallclaude_entscheidsuche__search_decisions
+  - mcp__plugin_bettercallclaude_fedlex-sparql__search_legislation
+  - mcp__plugin_bettercallclaude_fedlex-sparql__get_article
+  - mcp__plugin_bettercallclaude_fedlex-sparql__lookup_statute
+  - mcp__plugin_bettercallclaude_legal-citations__validate_citation
+  - mcp__plugin_bettercallclaude_legal-citations__extract_citations
+  - mcp__plugin_bettercallclaude_legal-citations__review_citations
+  - mcp__plugin_bettercallclaude_onlinekommentar__search_commentaries
+  - mcp__plugin_bettercallclaude_swiss-caselaw__search_decisions
+  - mcp__plugin_bettercallclaude_swiss-caselaw__get_decision
+  - mcp__plugin_bettercallclaude_swiss-caselaw__get_case_brief
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_leading_cases
+  - mcp__plugin_bettercallclaude_swiss-caselaw__find_relevant_erwaegung
+  - mcp__plugin_bettercallclaude_swiss-caselaw__check_claim_support
+  - mcp__plugin_bettercallclaude_swiss-caselaw__cite
+  - mcp__plugin_bettercallclaude_ollama__ollama_check_status
+  - mcp__plugin_bettercallclaude_ollama__ollama_classify_privacy
+---
+
+# /legal-way — Work One Decision Ticket
+
+You are invoked via `/bettercallclaude:legal-way`. You apply the `legal-wayfinder`
+skill in full. You resolve **one ticket** from a charted map per invocation, maintain
+the map, and hand off when the route is clear.
+
+## Parameters
+
+- First positional argument (optional): a ticket id or title. Without one, pick the lowest-numbered frontier ticket.
+- `--map=<slug-or-path>`: which map to work. Default: if exactly one map exists under `bcc-output/*/wayfinder/`, use it; if several, list and ask.
+- `--gate`: on handoff, pre-build a `/legal-goal` Goal Record so execution runs under the worker–evaluator loop.
+- `--list`: show every map in the working folder with frontier count, and stop.
+
+**Natural language equivalents**:
+- "prossima tessera" or "next ticket" → work the lowest-numbered frontier ticket
+- "elenco mappe" or "list maps" → `--list`
+- "con gate" or "with gate" → `--gate`
+
+**Output convention**: update the ticket file and `map.md` in place under
+`bcc-output/<matter>/wayfinder/`; write research memos and prototypes to `assets/`. Give
+in chat the resolution summary and the updated frontier. See `skills/shared/SKILL.md`.
+
+## Pre-Flight Checks
+
+1. **Map exists.** If none found: `ERROR: No wayfinder map found. Run /bettercallclaude:legal-chart first.`
+2. **Map not handed off.** If `status: handed-off`, show the map summary and stop — the matter is in execution.
+3. **Privacy mode loaded** from map frontmatter; `classifier` respected without re-probing.
+
+## Working Flow
+
+1. **Load the map** — the low-res view: Destination, Notes, Decisions so far, fog,
+   Out of scope. Do not open every ticket body; zoom into related tickets on demand.
+2. **Pick the ticket.** If the attorney named one, use it. Otherwise take the
+   lowest-numbered frontier ticket (open, unclaimed, all blockers resolved).
+   **Claim it first**: set `claimed-in` to an ISO timestamp before any work.
+   If the ticket is already claimed: refuse and show the frontier.
+3. **Resolve by type:**
+   - **research (AFK)**: researcher agent + MCP in standard priority order; memo in
+     `assets/`; every citation via `swiss-caselaw:cite` (R1), quotations verbatim (R2);
+     privacy pre-check per the map's mode and `classifier`.
+   - **grilling (HITL)**: conversation with the attorney, one question at a time.
+     Client facts, priorities, risk appetite — **never answer for the human**.
+   - **prototype (HITL)**: a cheap concrete artifact to react to — outline of the
+     Klageschrift, rough clause structure — linked from `assets/`.
+   - **task (HITL/AFK)**: a precise checklist handed to the attorney/client, or driven
+     alone where possible. Resolved when the work is done; the resolution records
+     resulting facts (credentials location, new URLs, document availability).
+4. **Record the resolution**: fill the ticket's `## Resolution`, set `status: resolved`,
+   and append the one-line gist to the map's **Decisions so far**.
+5. **Maintain the map**:
+   - Graduate newly-sharp fog into tickets (create-then-wire), clearing each graduated
+     patch from **Not yet specified**.
+   - If the decision reveals a ticket sits beyond the destination: `status: ruled-out`
+     plus one line in **Out of scope**.
+   - If the decision invalidates other tickets, update or delete them.
+   - Set map `status: working` if it was still `charting`.
+6. **Check for handoff.** If the frontier is empty AND **Not yet specified** is empty:
+   set `status: ready-for-handoff`, then emit the **handoff pack** — destination +
+   Decisions so far + linked assets — and route to `/legal-5step` or the orchestrator
+   (ask the attorney which). With `--gate`, first build the Goal Record via the
+   `/legal-goal` conventions and show it for confirmation. After delivery set
+   `status: handed-off`.
+   Otherwise stop with the resolution summary and the remaining frontier (by name).
+
+## Working Rules
+
+- **One ticket per invocation** — research tickets are the only exception and may be
+  batched.
+- **Honest termination**: never present an unresolved map as clear. Dead map (fog
+  non-empty, nothing graduatable, no open tickets) → surface to the attorney: the
+  destination needs redrawing or external input is missing (a `task` ticket).
+- Refer to tickets by name in everything the attorney reads.
+- The human-in-the-loop rule applies: the map never files, sends, signs, or transmits
+  anything.
+
+## Plugin Scope Constraint
+
+For all ticket work, use **exclusively** BetterCallClaude agents, skills, and MCP
+servers. Do not delegate legal work to generic or external skills, agents, or tools
+outside this plugin.
+
+## User Query
+
+$ARGUMENTS
+````
+
+- [ ] **Step 3: Run the command frontmatter and tool-name checks**
+
+Run: `head -1 bettercallclaude/commands/legal-way.md | grep -q '^---$' && grep -c "mcp__plugin_bettercallclaude" bettercallclaude/commands/legal-way.md`
+Expected: `OK`-prefixed pass; count = 19.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add bettercallclaude/commands/legal-way.md
+git commit -m "feat: add /legal-way command (work one decision ticket)"
+```
+
+---
+
+### Task 4: Briefing routing rule
+
+**Files:**
+- Modify: `bettercallclaude/commands/briefing.md` (Flags table + New Briefing flow)
+- Modify: `bettercallclaude/agents/briefing.md` (fog check before plan construction, anchored at the line `Using the classification and all collected answers, construct the execution plan.`)
+
+**Interfaces:**
+- Consumes: `/legal-chart` from Task 2.
+- Produces: no new artifacts — only a routing offer.
+
+- [ ] **Step 1: Add the `--chart` flag row to `commands/briefing.md`**
+
+In the Flags table, directly after the `| \`--skip-briefing\` | ... |` row, add:
+
+```markdown
+| `--chart` | Route to `/bettercallclaude:legal-chart` (wayfinder decision map) instead of a static execution plan — for matters too big or too foggy for one plan |
+```
+
+- [ ] **Step 2: Add the fog-routing bullet to the coordinator handoff in `commands/briefing.md`**
+
+In the **New Briefing** section, in the numbered list describing what the coordinator will do, append after the bullet `- Build a structured execution plan`:
+
+```markdown
+   - **Fog check**: if the matter is too foggy for a static plan (complexity 8+, or open decisions that depend on other open decisions), stop plan-building and offer: *"This matter is too foggy for a static plan — chart it instead?"* → `/bettercallclaude:legal-chart`
+```
+
+- [ ] **Step 3: Add the same fog check to the coordinator agent**
+
+In `bettercallclaude/agents/briefing.md`, replace the line:
+
+```markdown
+Using the classification and all collected answers, construct the execution plan.
+```
+
+with:
+
+```markdown
+**Fog check first.** If the matter is too foggy for a static plan — complexity 8+, or
+open decisions that depend on other open decisions — stop plan-building and offer the
+attorney: *"This matter is too foggy for a static plan — chart it instead?"* →
+`/bettercallclaude:legal-chart`. Only construct the execution plan when the way is
+clear or the attorney declines charting.
+
+Using the classification and all collected answers, construct the execution plan.
+```
+
+- [ ] **Step 4: Verify the edits**
+
+Run: `grep -c "legal-chart" bettercallclaude/commands/briefing.md bettercallclaude/agents/briefing.md`
+Expected: `bettercallclaude/commands/briefing.md:2` and `bettercallclaude/agents/briefing.md:1` (or higher).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add bettercallclaude/commands/briefing.md bettercallclaude/agents/briefing.md
+git commit -m "feat: route foggy high-complexity briefings to /legal-chart"
+```
+
+---
+
+### Task 5: Docs, counts, version bump
+
+**Files:**
+- Modify: `README.md:14` and `README.md:38` (27→29 commands, 16→17 skills)
+- Modify: `bettercallclaude/README.md:9` (same counts; version line → 4.10.0)
+- Modify: `AGENTS.md` (version header line 3 → 4.10.0; line 72 `# 27 command definitions` → 29; line 79 `# 16 skill modules` → 17)
+- Modify: `CHANGELOG.md` (new `[4.10.0]` entry at top)
+- Modify: `bettercallclaude/.claude-plugin/plugin.json` (`"version": "4.9.6"` → `"version": "4.10.0"`)
+- Modify: `bettercallclaude/commands/help.md` (two command rows after the `/bettercallclaude:briefing` row at line 63; one skill row after the `legal-evaluator` row at line 134)
+
+**Interfaces:**
+- Consumes: Tasks 1–4 (the files being counted and referenced).
+
+- [ ] **Step 1: Update counts and versions**
+
+Apply these exact replacements:
+- `README.md`: `21 agents, 27 commands, 16 skills` → `21 agents, 29 commands, 17 skills` (both occurrences, lines 14 and 38).
+- `bettercallclaude/README.md`: `**Version**: 4.9.6 -- 21 agents, 27 commands, 16 skills, 9 MCP servers.` → `**Version**: 4.10.0 -- 21 agents, 29 commands, 17 skills, 9 MCP servers.`
+- `AGENTS.md`: `> **Version**: 4.9.6` → `> **Version**: 4.10.0`; `# 27 command definitions` → `# 29 command definitions`; `# 16 skill modules` → `# 17 skill modules`.
+- `bettercallclaude/.claude-plugin/plugin.json`: `"version": "4.9.6"` → `"version": "4.10.0"`.
+
+- [ ] **Step 2: Add the CHANGELOG entry**
+
+Insert directly after the `---` following `All notable changes...` in `CHANGELOG.md`:
+
+```markdown
+## [4.10.0] - 2026-08-19
+
+### Added
+- **Wayfinder decision maps for big legal matters** — new `/legal-chart` and `/legal-way` commands plus the `legal-wayfinder` skill: chart a matter too big or too foggy for one session as a file-based map (destination, decisions so far, fog, out-of-scope) with decision tickets under `bcc-output/<matter>/wayfinder/`, work one ticket per invocation, hand off to `/legal-5step` or the orchestrator when the route is clear. Privacy follows the existing routing matrix including a no-ollama degradation path (fail-closed). `/briefing` now offers charting for foggy high-complexity matters.
+```
+
+- [ ] **Step 3: Add help.md rows**
+
+In `bettercallclaude/commands/help.md`, after the `| \`/bettercallclaude:briefing\` | ... |` row insert:
+
+```markdown
+| `/bettercallclaude:legal-chart` | Chart a big/foggy matter as a wayfinder decision map |
+| `/bettercallclaude:legal-way` | Work one decision ticket from a wayfinder map |
+```
+
+After the `| legal-evaluator | ... |` row insert:
+
+```markdown
+| legal-wayfinder | Decision-map decomposition for matters too big or foggy for one session |
+```
+
+- [ ] **Step 4: Verify counts and JSON validity**
+
+Run: `ls bettercallclaude/commands | wc -l && ls bettercallclaude/skills | wc -l && node -e "const p=JSON.parse(require('fs').readFileSync('bettercallclaude/.claude-plugin/plugin.json','utf8')); console.log(p.version)"`
+Expected: `29`, `17`, `4.10.0`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add README.md bettercallclaude/README.md AGENTS.md CHANGELOG.md bettercallclaude/.claude-plugin/plugin.json bettercallclaude/commands/help.md
+git commit -m "docs: bump to 4.10.0 — legal-wayfinder commands, skill, counts, changelog"
+```
+
+---
+
+### Task 6: Full validation and packaging
+
+**Files:**
+- Create: `dist/bettercallclaude-4.10.0.zip` (via packaging script)
+
+**Interfaces:**
+- Consumes: everything from Tasks 1–5.
+
+- [ ] **Step 1: Run the CI-equivalent structure checks locally**
+
+Run the "Validate Plugin Structure" steps from `.github/workflows/ci.yml` (marketplace.json, plugin.json, subdirectory contents, ollama bundle, .mcp.json, hook quoting, agent/command/skill frontmatter loops).
+Expected: every check OK, zero FAIL lines.
+
+- [ ] **Step 2: Package the plugin**
+
+Run: `bash scripts/package-plugin.sh`
+Expected: `dist/bettercallclaude-4.10.0.zip` created; script's final `unzip -l` shows 116 files (112 existing entries + 2 command files + 1 skill directory + SKILL.md).
+
+- [ ] **Step 3: Spot-check the zip contents**
+
+Run: `unzip -Z1 dist/bettercallclaude-4.10.0.zip | grep -E "legal-chart|legal-way|legal-wayfinder"`
+Expected: `commands/legal-chart.md`, `commands/legal-way.md`, `skills/legal-wayfinder/SKILL.md` present.
+
+- [ ] **Step 4: Commit the release artifact**
+
+```bash
+git add dist/bettercallclaude-4.10.0.zip
+git commit -m "chore: package v4.10.0"
+```

--- a/docs/workflows/legal-wayfinder.md
+++ b/docs/workflows/legal-wayfinder.md
@@ -1,0 +1,81 @@
+# Legal Wayfinder Workflow - Decision Maps for Foggy Matters
+
+**Persona**: Briefing Coordinator / Attorney 🗺️
+**Purpose**: Decompose a legal matter too big or too foggy for one execution plan into a decision map, resolve every open decision ticket-by-ticket, then hand off to execution with all decisions made
+
+---
+
+## Overview
+
+This workflow covers the **legal-wayfinder** protocol: the `legal-wayfinder` skill plus the `/bettercallclaude:legal-chart` and `/bettercallclaude:legal-way` commands. It is for matters where the bottleneck is *decisions*, not work.
+
+### When to use what
+
+| Tool | Use when | Input to execution |
+|------|----------|--------------------|
+| `/legal` gateway | Focused query, complexity 1-3 | Direct routing to one agent |
+| `/briefing` | Complex matter, but the route to the deliverable is plannable now | Structured execution plan |
+| `/legal-chart` (wayfinder) | Foggy matter: open decisions (limitation, forum, evidence availability, client risk appetite) make any plan premature | Decision map with tickets |
+| `/legal-5step` | End-to-end pipeline once decisions are settled | Full pipeline output |
+
+The rule of thumb: **`/briefing` plans the work when the decisions are clear; `/legal-chart` maps the decisions when they are not.** They connect in both directions — a fog check inside `/briefing` offers charting for high-complexity foggy matters, and `/legal-chart`'s early exit returns clear matters to `/briefing` or `/legal-5step`.
+
+### What You'll Learn
+
+- When a matter needs a decision map instead of an execution plan
+- How charting produces the map, tickets, and fog
+- How ticket-by-ticket work maintains the map
+- What the handoff pack guarantees (and forbids)
+
+### Time Investment
+
+- **Charting session**: 15-30 minutes (attorney grilling included)
+- **Per ticket**: 2-15 minutes for grilling/prototype; research tickets run AFK
+- **Handoff**: automatic once the map is clear
+
+---
+
+## Workflow Steps
+
+### Step 1: Chart the Matter (`/legal-chart`)
+
+1. **Name the destination first** — the deliverable, phrased concretely ("file-ready Klageschrift", "DD report for the SPA"). The destination fixes scope.
+2. **Breadth-first grilling** — one question at a time across jurisdiction, parties' positions, limitation, forum, evidence, risk appetite. Never deep on one thread; surface every open decision.
+3. **Early exit** — if no open decisions surface, no map is created; the command points you to `/briefing` or `/legal-5step` instead.
+4. **Create the map** at `bcc-output/YYYY-MM-DD-<slug>/wayfinder/map.md` with `status: charting`, fog sketched into *Not yet specified*.
+5. **Create tickets** that are sharp now (`tickets/tXX.md`), then wire `blocked-by` edges in a second pass. Everything not yet phrasable stays in the fog.
+6. **Fire research tickets** as parallel subagents — the only resolutions recorded during charting.
+
+### Step 2: Work Tickets (`/legal-way`)
+
+- One ticket per invocation; the default pick is the lowest-numbered **frontier** ticket (open, unclaimed, all blockers resolved or ruled out). Claiming stamps `claimed-in` before any work.
+- Resolve by type:
+  - **research (AFK)** — MCP servers in standard priority order; memo in `assets/`; R1 (cite via `cite`) and R2 (verbatim quotations) enforced.
+  - **grilling (HITL)** — questions to the attorney/client, one at a time; never answered for the human.
+  - **prototype (HITL)** — cheap artifact to react to (outline, clause skeleton) linked from `assets/`.
+  - **task (HITL/AFK)** — checklist work that unblocks a decision.
+- After each resolution: update **Decisions so far**, graduate newly sharp fog into tickets, rule out tickets that fall outside the destination, and mark invalidated ones.
+
+### Step 3: Hand Off
+
+- The gate: **every ticket `resolved` or `ruled-out` AND no fog** — claimed-but-unfinished tickets count as open, so in-flight work in another session blocks handoff.
+- On a clear map: `status: ready-for-handoff`, emit the **handoff pack** (destination + decisions + linked assets), route to `/legal-5step` or the orchestrator. `--gate` pre-builds a `/legal-goal` record for worker-evaluator execution.
+
+---
+
+## Map File Layout
+
+```
+bcc-output/YYYY-MM-DD-<slug>/wayfinder/
+├── map.md          # destination, notes, decisions so far, fog, out-of-scope
+├── tickets/        # t01.md, t02.md, ... (status, blocked-by, claimed-in, resolution)
+└── assets/         # research memos, prototypes
+```
+
+## Privacy
+
+No separate privacy rules: the map inherits the matter's privacy mode (`strict`/`balanced`/`cloud`), and privileged content follows the existing `privacy-routing` matrix — including the fail-closed degradation when ollama is not installed.
+
+## Honest Termination
+
+The map never presents an unresolved matter as clear. If the fog cannot be graduated and no ticket is workable (dead map), the protocol surfaces the block to the attorney instead of pretending completion — the destination needs redrawing, or external input is missing (itself a `task` ticket).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bettercallclaude",
-  "version": "4.9.6",
+  "version": "4.10.0",
   "private": true,
   "description": "Swiss Legal Intelligence Plugin for Claude",
   "scripts": {


### PR DESCRIPTION
## What

Legal-wayfinder: a decision-map protocol for legal matters, adapted from the "wayfinder" decomposition pattern. Decompose a foggy, high-complexity legal matter into a **chart of decision tickets**, then work the open **frontier** ticket-by-ticket until every decision is made — only then hand off to execution (`/draft`, `/strategy`, …).

Closes the v4.10.0 feature; bumps version to **4.10.0** (29 commands / 17 skills / 21 agents).

## New surfaces

- **Skill** `legal-wayfinder/SKILL.md` — ticket schema (`open` / `claimed` / `blocked` / `resolved` / `ruled-out`), frontier computation, fog check, handoff pack.
- **`/legal-chart`** (`commands/legal-chart.md`) — chart a decision map for a matter.
- **`/legal-way`** (`commands/legal-way.md`) — work one frontier ticket.
- **Briefing routing** — foggy high-complexity briefings are offered a route to `/legal-chart`; explicit `--chart` flag (Modes entry + pre-flight branch + NL trigger).

## Design & plan

- Spec: `docs/design/2026-08-19-legal-wayfinder-design.md`
- Plan: `docs/project-management/2026-08-19-legal-wayfinder-plan.md`

## Privacy

No new privacy rules — the skill delegates to the existing `privacy-routing` decision matrix (fail-closed when ollama is absent).

## Review status

Every task passed individual spec+quality review, plus a final whole-branch review. All findings fixed, most notably:

- **Frontier definition**: a blocker counts as satisfied when `resolved` **or** `ruled-out` — previously a ticket blocked by a `ruled-out` ticket was unreachable and could trigger premature handoff.
- **Handoff gate** (`9d998a4`): the gate is now "every ticket `resolved` or `ruled-out` AND fog empty" instead of "frontier empty" — a claimed ticket is excluded from the frontier by definition, so the old gate could hand off while a ticket was still mid-work in another session.
- `--chart` flag wired end-to-end (was declared but never consumed).
- `help.md` headers corrected to (29)/(17); README badge + What's New refreshed for v4.10.0.
- Working-dir placeholder unified to `bcc-output/YYYY-MM-DD-<slug>/wayfinder/`.

## Validation

- 29 commands / 17 skills / 21 agents on disk ✓
- `plugin.json` 4.10.0, parses ✓
- Package `dist/bettercallclaude-4.10.0.zip` (744 KB, 116 entries); pre-gate-fix build verified inside the zip — **repackage after final merge state before releasing** ✓

## Release plan

After merge → tag `v4.10.0`, repackage, upload `dist/bettercallclaude-4.10.0.zip` as the release asset (immutable — final build only).